### PR TITLE
Don't add patches with pending requests, review-, or checkin+ to "To Check In" list

### DIFF
--- a/app/user.js
+++ b/app/user.js
@@ -131,11 +131,13 @@ User.prototype.needsCheckin = function(callback) {
          if (!ready)
             return false;
 
-         // Do we have a review- or a pending request on the same patch?
+         // Don't add patches that have pending requests, have review-, or have
+         // checkin+.
          for (var i = 0; i < att.flags.length; ++i) {
             var flag = att.flags[i];
             if (flag.status == "?"
-                || flag.name == "review" && flag.status == "-") {
+                || flag.name == "review" && flag.status == "-"
+                || flag.name == "checkin" && flag.status == "+") {
                return false;
             }
          }

--- a/app/user.js
+++ b/app/user.js
@@ -117,11 +117,36 @@ User.prototype.needsCheckin = function(callback) {
 
       var requests = [];
 
+      function readyToLand(att) {
+         if (att.is_obsolete || !att.is_patch || !att.flags
+             || att.attacher.name != name) {
+            return false;
+         }
+
+         // Do we have at least one review+?
+         var ready = att.flags.filter(function(flag) {
+            return flag.name == "review" && flag.status == "+";
+         }).length > 0;
+
+         if (!ready)
+            return false;
+
+         // Do we have a review- or a pending request on the same patch?
+         for (var i = 0; i < att.flags.length; ++i) {
+            var flag = att.flags[i];
+            if (flag.status == "?"
+                || flag.name == "review" && flag.status == "-") {
+               return false;
+            }
+         }
+
+         return ready;
+      }
+
       bugs.forEach(function(bug) {
          var atts = [];
          bug.attachments.forEach(function(att) {
-            if (att.is_obsolete || !att.is_patch || !att.flags
-                || att.attacher.name != name) {
+            if (!readyToLand(att)) {
                return;
             }
             att.bug = bug;


### PR DESCRIPTION
The original problem was that the query would return bugs that contain attachments with review+, even if those attachments were obsolete. This fixes the problem by checking if the attachment has at least one review+ before adding it to the list. While I was at it, I also added checks to see if the attachment doesn't have pending requests, a review-, or checkin+.

This fixes issues #4 and #6.
