### PR TITLE
Use flag setter instead of attachment uploader in To Nag.

### DIFF
--- a/app/user.js
+++ b/app/user.js
@@ -208,12 +208,12 @@ User.prototype.awaitingFlag = function(callback) {
          }
          if (bug.attachments) {
             bug.attachments.forEach(function(att) {
-               if (att.is_obsolete || !att.is_patch || !att.flags
-                   || att.attacher.name != name) {
+               if (att.is_obsolete || !att.is_patch || !att.flags) {
                   return;
                }
+
                att.flags.some(function(flag) {
-                  if (flag.status == "?") {
+                  if (flag.status == "?" && flag.setter.name == name) {
                      att.bug = bug;
                      atts.push(att);
                      return true;


### PR DESCRIPTION
This is useful when working on behalf of new contributors.

For example, in bug 879308 I set the sr? flag for a patch from a contributor. It is then my responsibility to nag sicking and then land the patch.
