### PR TITLE
Display nags that are not necessarily patches

### DIFF
--- a/app/user.js
+++ b/app/user.js
@@ -208,7 +208,7 @@ User.prototype.awaitingFlag = function(callback) {
          }
          if (bug.attachments) {
             bug.attachments.forEach(function(att) {
-               if (att.is_obsolete || !att.is_patch || !att.flags) {
+               if (att.is_obsolete || !att.flags) {
                   return;
                }
 


### PR DESCRIPTION
This allows displaying nags that are not necessarily patches, like an attachment that has a 'feedback' flag, or a 'review' flag in the case where patches are not used (like for the SDK, for example, we have links to github PRs instead of patches)
