### PR TITLE
Fix html validation errors (Issue 48)

### DIFF
--- a/index.css
+++ b/index.css
@@ -75,11 +75,8 @@ footer > a {
   margin-right: 1px;
 }
 
-#login {
-  margin-left: 0.1em;
-}
-
 #login-form {
+  margin-left: 0.1em;
   display: inline-block;
 }
 

--- a/index.html
+++ b/index.html
@@ -172,16 +172,13 @@
     <div id="error-message"></div>
     <div id="header">
       <span id="title">
-        <img id="bug-icon" src="lib/bugzilla.png" title="Bugzilla"></img>
-         Todos
+        <img id="bug-icon" src="lib/bugzilla.png" title="Bugzilla">
+         Todos for
       </span>
-        <span id="login"> for
-          <form id="login-form" onsubmit="submitLogin()">
-            <input id="login-name"
-                   name="email" placeholder="Enter Bugzilla user..."/>
-          </form>
-        </span>
-      </span>
+      <form id="login-form" onsubmit="submitLogin()">
+        <input id="login-name"
+               name="email" placeholder="Enter Bugzilla user..."/>
+      </form>
     </div>
     <div id="content">
       <div class="patches-tab tabs">
@@ -207,7 +204,7 @@
     </footer>
   </div>
 
-  <iframe id="submit-iframe" name="submit-iframe" hidden="true">
+  <iframe id="submit-iframe" name="submit-iframe" hidden>
   </iframe>
   <script>
     /* From http://stackoverflow.com/questions/8400269/browser-native-autocomplete-for-ajaxed-forms */


### PR DESCRIPTION
http://html5.validator.nu/?doc=https%3A%2F%2Fharthur.github.io%2Fbugzilla-todos%2F

```
Error: Stray end tag img.
From line 175, column 68; to line 175, column 73
Bugzilla"></img>↩

Error: Element form not allowed as child of element span in this context. (Suppressing further errors from this subtree.)
From line 179, column 11; to line 179, column 57
<form id="login-form" onsubmit="submitLogin()">↩

Error: Stray end tag span.
From line 184, column 7; to line 184, column 13
an>↩ </span>↩ <

Error: Bad value true for attribute hidden on element iframe.
From line 210, column 3; to line 210, column 64
</div>↩↩ <iframe id="submit-iframe" name="submit-iframe" hidden="true">↩ </i
```
