### PR TITLE
Fix app installation for the GitHub hosted & Marketplace version (Issue 45)

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,13 +1,13 @@
 {
   "name": "Bugzilla Todos",
   "description": "A Bugzilla todo list for Mozilla developers",
-  "launch_path": "/index.html",
+  "launch_path": "/bugzilla-todos/index.html",
   "developer": {
     "name": "Heather Arthur",
     "url": "http://github.com/harthur/bugzilla-todos"
   },
   "default_locale": "en-US",
   "icons": {
-    "128": "/bugzilla-todos-128.png"
+    "128": "/bugzilla-todos/bugzilla-todos-128.png"
   }
 }


### PR DESCRIPTION
This fixes issue 45. Ideally both the Github hosted version and http://bugmotodo.org would work, but that doesn't appear to be possible - and at the moment the Marketplace app is broken due to this.
