### PR TITLE
Increase max-width on container

### DIFF
--- a/index.css
+++ b/index.css
@@ -40,7 +40,7 @@ footer > a {
 }
 
 #container {
-  max-width: 560px;
+  max-width: 580px;
   margin: 0 auto;
   text-align: center;
 }


### PR DESCRIPTION
Sometimes when I have a lot of new activity the headers end up wrapping into a new line (see screenshot).  Bumping up the max-width a bit helps put them back on one line.

![lots of notifications](https://cloud.githubusercontent.com/assets/95570/3858336/c068fa20-1f0c-11e4-9899-348079f9aca4.png)
