### PR TITLE
Count Github PR and Reviewboard attachments as patches too (issue 58)

### DIFF
--- a/app/user.js
+++ b/app/user.js
@@ -121,7 +121,7 @@ User.prototype.needsCheckin = function(callback) {
       var requests = [];
 
       function readyToLand(att) {
-         if (att.is_obsolete || !att.is_patch || !att.flags
+         if (att.is_obsolete || !utils.isCodeAttachment(att) || !att.flags
              || att.attacher.name != name) {
             return false;
          }
@@ -262,7 +262,7 @@ User.prototype.toFix = function(callback) {
          }
 
          var patchForReview = bug.attachments.some(function(att) {
-            if (att.is_obsolete || !att.is_patch || !att.flags) {
+            if (att.is_obsolete || !utils.isCodeAttachment(att) || !att.flags) {
                return false;
             }
             var reviewFlag = att.flags.some(function(flag) {

--- a/app/utils.js
+++ b/app/utils.js
@@ -36,6 +36,11 @@ var utils = {
      return name.replace(/\W/g, "-");
    },
 
+   isCodeAttachment : function(att) {
+     return att.is_patch || att.content_type == "text/x-github-pull-request"
+            || att.content_type == "text/x-review-board-request";
+   },
+
    spinner : function(elem, inline) {
     var spinner = $("<img src='lib/indicator.gif' class='spinner'></img>");
     if (inline) {


### PR DESCRIPTION
Also count attachments with a mimetype of "text/x-github-pull-request"
or "text/x-review-board-request" as a patch, when determining whether a
bug should appear on "to checkin" and "to fix" - rather than treating
them like a normal non-code attachment.

Fixes https://github.com/harthur/bugzilla-todos/issues/58
