### PR TITLE
Fix mixed content warning from CSS import

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,5 +1,5 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,300,500,700);
-@import url(http://fonts.googleapis.com/css?family=Roboto+Slab:400,300,700);
+@import url(//fonts.googleapis.com/css?family=Roboto:400,300,500,700);
+@import url(//fonts.googleapis.com/css?family=Roboto+Slab:400,300,700);
 
 * {
   -moz-box-sizing: border-box;


### PR DESCRIPTION
When using https://harthur.github.io/bugzilla-todos/ there is a mixed content warning after https://github.com/harthur/bugzilla-todos/commit/2b0f8500dbbd41a5874aa15e562e3e50c189bc18

10:58:07.263 Blocked loading mixed active content "http://fonts.googleapis.com/css?family=Roboto:400,300,500,700"[Learn More] bugzilla-todos
10:58:07.264 Blocked loading mixed active content "http://fonts.googleapis.com/css?family=Roboto+Slab:400,300,700"[Learn More] bugzilla-todos
