### PR TITLE
Import font CSS using https to fix mixed content warning

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,5 +1,5 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,300,500,700);
-@import url(http://fonts.googleapis.com/css?family=Roboto+Slab:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,300,500,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto+Slab:400,300,700);
 
 * {
   -moz-box-sizing: border-box;


### PR DESCRIPTION
Using the protocol-relative "//fonts..." form breaks when running from the local filesystem, so use "https://fonts..." since it still works without mixed content warnings when accessing index.html over http.
