### PR TITLE
Use JS to redirect http to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,17 @@
   <link rel="stylesheet" href="lib/normalize.css">
   <link rel="stylesheet" href="index.css" type="text/css">
 
+  <script type="text/javascript">
+    (function() {
+      // Github pages doesn't have a force-https pref, so this is the best we can do.
+      // Whilst this can still be MITMed, it increases the chance that people will
+      // bookmark and share the https URLs.
+      if (/.*\.github\.io/.test(window.location.host) && window.location.protocol == "http:") {
+        window.location.protocol = "https";
+      }
+    })();
+  </script>
+
   <script src="lib/react-0.12.0.js"></script>
   <script src="lib/jquery-1.6.4.min.js" type="text/javascript"></script>
   <script src="lib/jquery.timeago.js" type="text/javascript"></script>
@@ -51,8 +62,6 @@
 
   <iframe id="submit-iframe" name="submit-iframe" hidden>
   </iframe>
-  <script>
-  </script>
   <script type="text/javascript">
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-37841258-1']);


### PR DESCRIPTION
Github pages doesn't have a force-https pref, so this is the best we can do.
Whilst this can still be MITMed, it increases the chance that people will
bookmark and share the https URLs.
