### PR TITLE
Patches with checkin+ should not prevent a bug from being in "To Fix"

### DIFF
--- a/app/user.js
+++ b/app/user.js
@@ -336,7 +336,10 @@ var BugzillaUser = (function() {
             return flag.name == "review" && (flag.status == "?" ||
               flag.status == "+");
           });
-          return reviewFlag;
+          var checkedIn = att.flags.some(function(flag) {
+            return flag.name == "checkin" && flag.status == "+";
+          });
+          return reviewFlag && !checkedIn;
         });
         return !patchForReview;
       });


### PR DESCRIPTION
Prior to this change, bugs with a reviewed but checked in patch did not appear on any of the Bugzilla-Todos sections, since they were also excluded from "To Check In". Instead now they appear on "To Fix", since there is either (a) work still to be done in the bug, or (b) the user forgot to close the bug, in which case at least showing it _somewhere_ will mean they are reminded to close it.

Fixes #69.
