### PR TITLE
Improve build instructions in README & add build cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 index_files
 node_modules
+build/.module-cache

--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ For the given username, Bugzilla Todos will display:
 
 Bugzilla Todos uses [bz.js](https://github.com/canuckistani/bz.js) to make calls to the Bugzilla REST API. The Bugzilla queries used in the app are located in `app/user.js`.
 
-The UI uses the [React](http://facebook.github.io/react/) library. Build the react JSX files with:
+The UI uses the [React](http://facebook.github.io/react/) library. With [Node.js](http://nodejs.org/) installed, install react-tools using:
+
+```
+npm install react-tools -g
+```
+
+Then build the react JSX files with:
 
 ```
 jsx app/ build/ --source-map-inline --watch &
 ```
+
+Note: All files in app/ are currently built, but only those using JSX syntax need to be checked into the repository - the others are used untouched from the app directory.


### PR DESCRIPTION
The readme currently doesn't say how to install jsx - which meant that my first attempt involved |npm install jsx| which is completely not what I wanted, but that didn't become apparent for some time, due to the errors returned making it look like the suggested build params were just wrong in the readme.

Also to make things confusing, the command given builds all files in app/, outputting them in build/ even though we've only checked some of the build/ files into the repo - so I've added a note to explain. Longer term perhaps moving to a gulp/grunt build script might be better - or even just renaming the JSX syntax files to .jsx and passing |-x jsx| to jsx.

I've also added a .gitignore entry for the jsx cache output.
