### PR TITLE
Remove Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,16 +62,5 @@
 
   <iframe id="submit-iframe" name="submit-iframe" hidden>
   </iframe>
-  <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-37841258-1']);
-    _gaq.push(['_trackPageview']);
-
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
The GA code was added in January 2013, so is presumably still using Heather's account. Now that the project has been passed on, I'm not sure it makes sense to continue reporting to her GA account. In addition, there are some Mozillians who avoid sites that use GA, so let's just remove it.
