### PR TITLE
Add type attribute to input

### DIFF
--- a/app/bugzilla-todos.js
+++ b/app/bugzilla-todos.js
@@ -421,6 +421,7 @@ var TodosApp = (function() {
           <span id="login"> for
             <form id="login-form" onSubmit={this.handleSubmit}>
               <input id="login-name"
+                     type="email"
                      name="email" placeholder="Enter Bugzilla user..."
                      ref="email"/>
             </form>


### PR DESCRIPTION
Add the attribute type="email" to the email input tag
in order to display the proper keyboard on mobile devices.
