### PR TITLE
Remove client-side redirect now GitHub pages support enforcing HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,17 +11,6 @@
   <link rel="stylesheet" href="lib/normalize.css">
   <link rel="stylesheet" href="index.css" type="text/css">
 
-  <script type="text/javascript" defer>
-    (function() {
-      // Github pages doesn't have a force-https pref, so this is the best we can do.
-      // Whilst this can still be MITMed, it increases the chance that people will
-      // bookmark and share the https URLs.
-      if (/.*\.github\.io/.test(window.location.host) && window.location.protocol == "http:") {
-        window.location.protocol = "https";
-      }
-    })();
-  </script>
-
   <script src="lib/react-0.12.0.js" defer></script>
   <script src="lib/jquery-1.6.4.min.js" type="text/javascript" defer></script>
   <script src="lib/jquery.timeago.js" type="text/javascript" defer></script>


### PR DESCRIPTION
GitHub pages now support enforcing HTTPS (which has been enabled in #87), so the client-side redirect can now be removed. See:
https://help.github.com/articles/securing-your-github-pages-site-with-https/
